### PR TITLE
Issue-1285: Upgrade to Jackson 2.9.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <version.hamcrest>1.3</version.hamcrest>
         <version.hazelcast>3.10.2</version.hazelcast>
         <version.httpclient>4.5</version.httpclient>
-        <version.jackson>2.9.8</version.jackson>
+        <version.jackson>2.9.9</version.jackson>
         <version.jcl>1.7.25</version.jcl>
         <version.jsr305>3.0.2</version.jsr305>
         <version.findbugs.annotations>3.0.1</version.findbugs.annotations>


### PR DESCRIPTION
Fixes strongbox/strongbox#1285.

Tasks carried out:
* [x] Update the version of the Jackson dependencies in the [`strongbox-proto-parent`](https://github.com/strongbox/strongbox-proto-parent/) project.

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.