### PR TITLE
Issue #1565 - org.apache.tomcat:catalina dependency has been dropped …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1190,19 +1190,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.tomcat</groupId>
-                <artifactId>catalina</artifactId>
-                <version>6.0.53</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apache.tomcat</groupId>
-                        <artifactId>servlet-api</artifactId>
-                    </exclusion>
-                </exclusions>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
                 <groupId>com.github.ThoughtWire</groupId>
                 <artifactId>hazelcast-locks</artifactId>
                 <version>v1.0.1</version>


### PR DESCRIPTION
# Task Description
We should no longer need this dependency. This task should verify this theory, and, if so, we should remove this from all pom.xml files.

# Tasks
The following tasks will need to be carried out:

- [x] Remove this from the strongbox-proto-parent) project.
- [x] Remove this from the strongbox-parent) project.
- [x] Remove this from all pom.xml files in the strongbox project.

# Acceptance Test
 - [x] Building the code with mvn clean install -Dintegration.tests still works.
 - [x] Running mvn spring-boot:run in the strongbox-web-core still starts up the application correctly.
 - [x] Building the code and running the strongbox-distribution from a zip or tar.gz still works.
 - [~] The tests in the strongbox-web-integration-tests still run properly.

was not able to get the gradle s-w-i-t task running as it kept failing to build javadocs (very likely because of my build environment)