### PR TITLE
Drop the org.apache.tomcat:catalina dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1190,19 +1190,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.tomcat</groupId>
-                <artifactId>catalina</artifactId>
-                <version>6.0.53</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apache.tomcat</groupId>
-                        <artifactId>servlet-api</artifactId>
-                    </exclusion>
-                </exclusions>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
                 <groupId>com.github.ThoughtWire</groupId>
                 <artifactId>hazelcast-locks</artifactId>
                 <version>v1.0.1</version>


### PR DESCRIPTION
Fixes [strongbox #1565](https://github.com/strongbox/strongbox/issues/1565#issue-513023450). See [strongbox-parent #52](https://github.com/strongbox/strongbox-parent/pull/52#issue-333698102).