### PR TITLE
removed maven-war-plugin from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,19 +142,7 @@
                             </manifestEntries>
                         </archive>
                     </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-war-plugin</artifactId>
-                    <version>3.1.0</version>
-                    <configuration>
-                        <archive>
-                            <manifestEntries>
-                                <Strongbox-Implementation-Revision>${strongbox.revision}</Strongbox-Implementation-Revision>
-                            </manifestEntries>
-                        </archive>
-                    </configuration>
-                </plugin>
+                </plugin>       
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
This pull and strongbox/strongbox-parent#54 fixes strongbox/strongbox#1562

### Acceptance Test

- [x] Building the code with mvn clean install -Dintegration.tests still works.
- [x] Running mvn spring-boot:run in the strongbox-web-core still starts up the application correctly.
- [x] Building the code and running the strongbox-distribution from a zip or tar.gz still works.
- [x] The tests in the strongbox-web-integration-tests still run properly.